### PR TITLE
Fix Data Preview numbering.

### DIFF
--- a/sizing.tex
+++ b/sizing.tex
@@ -10,10 +10,10 @@ This model assumes the following processing:
 \item Precursor data (HSC RC2 and a similarly-sized DESC DC2 subset) is reprocessed each month during the Construction period using the Data Release Production (DRP).
 \item A large precursor reprocessing of HSC PDR2 (or equivalent) is completed twice a year.
 Products from one of these reprocessings will be released as Data Preview 0.
-One or more of these processings could be devoted instead to LSSTCam science data during Commissioning.
+One or more of these processings during Commissioning could be devoted instead to ComCam science data for Data Preview 1 or LSSTCam science data in preparation for Data Preview 2.
 \item Alert Production (AP) processing happens continuously as LSSTCam science images are obtained.
 AP hardware is purchased in FY22 to support this, presumably on a limited basis during that year and then to whatever extent possible during the first year of the survey.
-\item Commissioning processing of LSSTCam science images for Data Preview 1 is assumed to happen towards the end of FY22 as a single execution of the DRP.
+\item Commissioning processing of LSSTCam science images for Data Preview 2 is assumed to happen towards the end of FY22 as a single execution of the DRP.
 The hardware for this can be purchased early in that fiscal year.
 \item Annual DRP execution starts at the beginning of LSST Operations Year 2 with the processing for DR2.
 The hardware for each year's processing must be purchased and ready for use at the beginning of the year, so it is allocated in the tables to the prior fiscal year, when the images for that processing were taken.


### PR DESCRIPTION
Make ComCam processing explicit as a replacement for a precursor run.